### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -662,19 +662,19 @@ Indices
     :scale: 100%
     :target: https://readthedocs.org/builds/fuefit/
 
-.. |pypi-status| image::  https://pypip.in/v/fuefit/badge.png
+.. |pypi-status| image::  https://img.shields.io/pypi/v/fuefit.svg
     :target: https://pypi.python.org/pypi/fuefit/
     :alt: Latest Version in PyPI
 
-.. |python-ver| image:: https://pypip.in/py_versions/fuefit/badge.svg
+.. |python-ver| image:: https://img.shields.io/pypi/pyversions/fuefit.svg
     :target: https://pypi.python.org/pypi/fuefit/
     :alt: Supported Python versions
 
-.. |dev-status| image:: https://pypip.in/status/fuefit/badge.svg
+.. |dev-status| image:: https://img.shields.io/pypi/status/fuefit.svg
     :target: https://pypi.python.org/pypi/fuefit/
     :alt: Development Status
 
-.. |downloads-count| image:: https://pypip.in/download/fuefit/badge.svg?period=week
+.. |downloads-count| image:: https://img.shields.io/pypi/dw/fuefit.svg
     :target: https://pypi.python.org/pypi/fuefit/
     :alt: Downloads
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20fuefit))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `fuefit`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.